### PR TITLE
Update "find a pizza I can eat" function

### DIFF
--- a/mrdavidlaing-javascript-koans-64317bd/koans/AboutApplyingWhatWeHaveLearnt.js~
+++ b/mrdavidlaing-javascript-koans-64317bd/koans/AboutApplyingWhatWeHaveLearnt.js~
@@ -40,14 +40,14 @@ describe("About Applying What We Have Learnt", function() {
       var productsICanEat = [];
       
   
-       var productsICanEat = products.filter( function (x) { return  x.containsNuts === true && _(x.ingredients).all(function(y) { return y !== "mushrooms"}) });
+       var productsICanEat = products.filter( function (x) { return  x.containsNuts === false && _(x.ingredients).all(function(y) { return y !== "mushrooms"}) });
      
 
       
       /* solve using filter() & all() / any() */
 
 
-      expect(productsICanEat.length).toBe(2);
+      expect(productsICanEat.length).toBe(1);
   });
 
   /*********************************************************************************/


### PR DESCRIPTION
The function was able to pass the test due to setting the test length of productsICanEat to two but that number should be one. Originally returned two pizzas by checking for a pizza that contains nuts && does not have mushrooms. Now it returns one pizza that does not contain nuts && does not have mushrooms. Also changed the length that we test for.